### PR TITLE
Optimized Multicallable to call multiple functions on a contract

### DIFF
--- a/src/Multicallable.sol
+++ b/src/Multicallable.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.13;
+pragma experimental ABIEncoderV2;
+
+abstract contract Multicallable {
+    function multicall(address target, bytes[] calldata data) external payable returns (bytes[] memory) {
+        assembly {
+            mstore(0x00, 0x20)
+            mstore(0x20, data.length) // Store `data.length` into `results`.
+            // Early return if no data.
+            if iszero(data.length) { return(0x00, 0x40) }
+
+            let results := 0x40
+            // `shl` 5 is equivalent to multiplying by 0x20.
+            let end := shl(5, data.length)
+            // Copy the offsets from calldata into memory.
+            calldatacopy(0x40, data.offset, end)
+            // Pointer to the top of the memory (i.e. start of the free memory).
+            let resultsOffset := end
+
+            for { end := add(results, end) } 1 {} {
+                // The offset of the current bytes in the calldata.
+                let o := add(data.offset, mload(results))
+                let memPtr := add(resultsOffset, 0x40)
+                // Copy the current bytes from calldata to the memory.
+                calldatacopy(
+                    memPtr,
+                    add(o, 0x20), // The offset of the current bytes' bytes.
+                    calldataload(o) // The length of the current bytes.
+                )
+                if iszero(call(gas(), target, 0, memPtr, calldataload(o), 0x00, 0x00)) {
+                    // Bubble up the revert if the delegatecall reverts.
+                    returndatacopy(0x00, 0x00, returndatasize())
+                    revert(0x00, returndatasize())
+                }
+                // Append the current `resultsOffset` into `results`.
+                mstore(results, resultsOffset)
+                results := add(results, 0x20)
+                // Append the `returndatasize()`, and the return data.
+                mstore(memPtr, returndatasize())
+                returndatacopy(add(memPtr, 0x20), 0x00, returndatasize())
+                // Advance the `resultsOffset` by `returndatasize() + 0x20`,
+                // rounded up to the next multiple of 32.
+                resultsOffset := and(add(add(resultsOffset, returndatasize()), 0x3f), 0xffffffffffffffe0)
+                if iszero(lt(results, end)) { break }
+            }
+            return(0x00, add(resultsOffset, 0x40))
+        }
+    }
+}

--- a/test/Multicallable.t.sol
+++ b/test/Multicallable.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {Multicallable} from "../src/Multicallable.sol";
+import {SomeContract} from "./mocks/SomeContract.sol";
+
+contract MulticallableTest is Multicallable, Test {
+    SomeContract somecontract;
+
+    address public target;
+
+    function setUp() public {
+        somecontract = new SomeContract();
+        target = address(somecontract);
+    }
+
+    function multicallOriginal(address _target, bytes[] calldata data) public returns (bytes[] memory) {
+        bytes[] memory results = new bytes[](data.length);
+        for (uint256 i = 0; i < data.length; i++) {
+            (bool success, bytes memory result) = _target.call(data[i]);
+            require(success);
+            results[i] = result;
+        }
+        return results;
+    }
+
+    function testMulticallableRevertWithMessage(string memory revertMessage) public {
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeWithSelector(SomeContract.revertsWithString.selector, revertMessage);
+        vm.expectRevert(bytes(revertMessage));
+        this.multicall(target, data);
+    }
+
+    function testMulticallableRevertWithMessage() public {
+        testMulticallableRevertWithMessage("Milady");
+    }
+
+    function testMulticallableRevertWithCustomError() public {
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeWithSelector(SomeContract.revertsWithCustomError.selector);
+        vm.expectRevert(SomeContract.CustomError.selector);
+        this.multicall(target, data);
+    }
+
+    function testMulticallableRevertWithNothing() public {
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeWithSelector(SomeContract.revertsWithNothing.selector);
+        vm.expectRevert();
+        this.multicall(target, data);
+    }
+
+    function testMulticallableReturnDataIsProperlyEncoded(uint256 a0, uint256 b0, uint256 a1, uint256 b1) public {
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeWithSelector(SomeContract.returnsTuple.selector, a0, b0);
+        data[1] = abi.encodeWithSelector(SomeContract.returnsTuple.selector, a1, b1);
+        bytes[] memory returnedData = this.multicall(target, data);
+        SomeContract.Tuple memory t0 = abi.decode(returnedData[0], (SomeContract.Tuple));
+        SomeContract.Tuple memory t1 = abi.decode(returnedData[1], (SomeContract.Tuple));
+        assertEq(t0.a, a0);
+        assertEq(t0.b, b0);
+        assertEq(t1.a, a1);
+        assertEq(t1.b, b1);
+    }
+
+    function testMulticallableReturnDataIsProperlyEncoded(string memory sIn0, string memory sIn1, uint256 n) public {
+        n = n % 2;
+        bytes[] memory dataIn = new bytes[](n);
+        if (n > 0) {
+            dataIn[0] = abi.encodeWithSelector(SomeContract.returnsString.selector, sIn0);
+        }
+        if (n > 1) {
+            dataIn[1] = abi.encodeWithSelector(SomeContract.returnsString.selector, sIn1);
+        }
+        bytes[] memory dataOut = this.multicall(target, dataIn);
+        if (n > 0) {
+            assertEq(abi.decode(dataOut[0], (string)), sIn0);
+        }
+        if (n > 1) {
+            assertEq(abi.decode(dataOut[1], (string)), sIn1);
+        }
+    }
+
+    function testMulticallableReturnDataIsProperlyEncoded() public {
+        testMulticallableReturnDataIsProperlyEncoded(0, 1, 2, 3);
+    }
+
+    function testMulticallableBenchmark() public {
+        unchecked {
+            bytes[] memory data = new bytes[](10);
+            for (uint256 i; i != data.length; ++i) {
+                data[i] = abi.encodeWithSelector(SomeContract.returnsTuple.selector, i, i + 1);
+            }
+            bytes[] memory returnedData = this.multicall(target, data);
+            assertEq(returnedData.length, data.length);
+        }
+    }
+
+    function testMulticallableOriginalBenchmark() public {
+        unchecked {
+            bytes[] memory data = new bytes[](10);
+            for (uint256 i; i != data.length; ++i) {
+                data[i] = abi.encodeWithSelector(SomeContract.returnsTuple.selector, i, i + 1);
+            }
+            bytes[] memory returnedData = this.multicallOriginal(target, data);
+            assertEq(returnedData.length, data.length);
+        }
+    }
+
+    function testMulticallableWithNoData() public {
+        bytes[] memory data = new bytes[](0);
+        assertEq(this.multicall(target, data).length, 0);
+    }
+
+    function testMulticallablePreservesMsgValue() public {
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeWithSelector(SomeContract.pay.selector);
+        this.multicall{value: 3}(target, data);
+        assertEq(somecontract.paid(), 3);
+    }
+
+    function testMulticallablePreservesMsgValueUsedTwice() public {
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeWithSelector(SomeContract.pay.selector);
+        data[1] = abi.encodeWithSelector(SomeContract.pay.selector);
+        this.multicall{value: 3}(target, data);
+        assertEq(somecontract.paid(), 6);
+    }
+
+    function testMulticallablePreservesMsgSender() public {
+        address caller = address(uint160(0xbeef));
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeWithSelector(SomeContract.returnsSender.selector);
+        vm.prank(caller);
+        address returnedAddress = abi.decode(this.multicall(target, data)[0], (address));
+        assertEq(caller, returnedAddress);
+    }
+}

--- a/test/mocks/SomeContract.sol
+++ b/test/mocks/SomeContract.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.13;
+
+import "../../src/Multicallable.sol";
+
+contract SomeContract {
+    error CustomError();
+
+    struct Tuple {
+        uint256 a;
+        uint256 b;
+    }
+
+    function revertsWithString(string memory e) external pure {
+        revert(e);
+    }
+
+    function revertsWithCustomError() external pure {
+        revert CustomError();
+    }
+
+    function revertsWithNothing() external pure {
+        revert();
+    }
+
+    function returnsTuple(uint256 a, uint256 b) external pure returns (Tuple memory tuple) {
+        tuple = Tuple({a: a, b: b});
+    }
+
+    function returnsString(string calldata s) external pure returns (string memory) {
+        return s;
+    }
+
+    uint256 public paid;
+
+    function pay() external payable {
+        paid += msg.value;
+    }
+
+    function returnsSender() external view returns (address) {
+        return msg.sender;
+    }
+}


### PR DESCRIPTION
References:
 - https://github.com/Vectorized/solady/issues/278

Most of the code is replicated from the Vectorized/solady repo. 

Some notable changes:
 - Uses `call` instead of `deletagatecall`
 - The calls are performed on a target contract unlike Solday
 - The tests are the same as the solady repo with a little change in the setup
 - Can not pass `msg.value`
 - The `msg.sender` is not the original sender

Things to do next:
 - Support multiple targets
 - gas analysis

